### PR TITLE
Modify basic_auth error to return 400, rather than 401

### DIFF
--- a/volunteermatching/api/auth.py
+++ b/volunteermatching/api/auth.py
@@ -22,7 +22,7 @@ def verify_password(username, password):
 # Defines the error response if HTTPBasicAuth fails
 @basic_auth.error_handler
 def basic_auth_error_handler():
-    return error_response(401)
+    return error_response(400, message='username or password incorrect')
 
 # Defines the HTTPTokenAuth callback function token verification used
 # when token auth is used on a route function


### PR DESCRIPTION
This does not alter the token_auth error which would still return a 401 error. The token_auth needs additional error handling to cover the token expiration so it can be covered separately. Close #65