### PR TITLE
UI/UX: Add Pagination to all search pages. Close #97

### DIFF
--- a/client/src/components/SearchBar/SearchBar.js
+++ b/client/src/components/SearchBar/SearchBar.js
@@ -4,48 +4,20 @@ import axios from 'axios';
 import './SearchBar.scss';
 
 export default class SearchBar extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      search: '',
-    };
-  }
-
-  submitSearch(e) {
-    e.preventDefault();
-    const { search } = this.state;
-
-    axios.get(`/api/${this.props.endpoint}?search=${search}`)
-      .then(res => {
-        this.props.set({ searchResult: res.data });
-      })
-      .catch(err => {
-        this.props.set({ searchError: {
-          text: err.response.data.message,
-          type: 'alert-danger'
-        }});
-      })
-  }
-
-  setByName(e) {
-    this.setState({ [e.target.name]: e.target.value });
-  }
-
   render () {
     const upper = this.props.endpoint ? this.props.endpoint[0].toUpperCase() + this.props.endpoint.substr(1) : '';
     const title = this.props.title;
 
     return (
-      <form onSubmit={this.submitSearch.bind(this)}>
+      <form onSubmit={this.props.submitSearch.bind(this)}>
         <label>Search {title || upper}</label>
         <div className="input-group">
           <input
             className="form-control"
             name="search"
             placeholder={`Search ${title || upper}`}
-            onChange={this.setByName.bind(this)}
-            value={this.state.search}
+            onChange={(e) => { this.props.setValue({ search: e.target.value }); }}
+            value={this.props.search}
           />
           <div className="input-group-append">
             <input className="btn btn-primary" type="submit" value="Search"/>

--- a/client/src/pages/Opportunities/Opportunities.js
+++ b/client/src/pages/Opportunities/Opportunities.js
@@ -12,7 +12,55 @@ export default class Opportunties extends Component {
 
     this.state = {
       searchResult: {},
-      searchError: {}
+      searchError: {},
+      page: 1,
+      per_page: 10,
+      search: '',
+    }
+  }
+
+  search() {
+    const { search, page, per_page } = this.state;
+    axios.get(`/api/opportunities?search=${search}&page=${page}&per_page=${per_page}`, { headers: { Authorization: 'Bearer ' + this.props.token }})
+    .then(res => {
+      this.setState({ searchResult: res.data });
+    })
+    .catch(err => {
+      this.setState({ searchError: {
+        text: err.response.status + ' ' + err.response.statusText,
+        type: 'alert-danger'
+      }});
+    });
+  }
+
+  hasNextPage() {
+    let nextPage = this.state.page + 1;
+    const { searchResult } = this.state;
+    if (searchResult && searchResult._meta && searchResult._meta.total_pages) {
+      if (nextPage <= searchResult._meta.total_pages) {
+        return true;
+      }
+    }
+  }
+
+  hasLastPage() {
+    const lastPage = this.state.page - 1;
+    if (lastPage > 0) {
+      return true;
+    }
+  }
+
+  nextPage() {
+    const nextPage = this.state.page + 1;
+    if (this.hasNextPage()) {
+      this.setState({ page: nextPage}, this.search);
+    }
+  }
+
+  lastPage() {
+    const lastPage = this.state.page - 1;
+    if (this.hasLastPage()) {
+      this.setState({ page: lastPage }, this.search);
     }
   }
 
@@ -21,16 +69,7 @@ export default class Opportunties extends Component {
   }
 
   componentDidMount() {
-    axios.get('/api/opportunities')
-      .then(res => {
-        this.setState({ searchResult: res.data });
-      })
-      .catch(err => {
-        this.setState({ searchError: {
-          text: err.status,
-          type: 'alert-danger'
-        }});
-      });
+    this.search();
   }
 
   render () {
@@ -41,13 +80,34 @@ export default class Opportunties extends Component {
         <h2>Search Opportunities</h2>
         <SearchBar
           endpoint='opportunities'
-          set={this.set.bind(this)}
+          setValue={this.set.bind(this)}
+          search={this.state.search}
+          submitSearch={this.search.bind(this)}
         />
         <Alert {...this.state.searchError}/>
         <br/><br/>
         {items && items.length > 0 ? items.map((val) => {
           return <Thumb {...val}/>;
         }): <p className="text-danger">No Opportunities found.</p>}
+        <nav className="text-center row justify-content-center">
+          <ul className="pagination">
+            <li className="page-item">
+              <button className={`btn btn-${this.hasLastPage() ? 'info': 'primary'}`} disabled={!this.hasLastPage()} onClick={this.lastPage.bind(this)}>
+                <span aria-hidden="true">&laquo; </span>
+                <span className=""> Last</span>
+              </button>
+            </li>
+            <li className="page-item">
+              <button className="btn btn-info" disabled>{this.state.page}</button>
+            </li>
+            <li className="page-item">
+              <button className={`btn btn-${this.hasNextPage() ? 'info': 'primary'}`} disabled={!this.hasNextPage()} onClick={this.nextPage.bind(this)}>
+                <span>Next </span>
+                <span aria-hidden="true">&raquo;</span>
+              </button>
+            </li>
+          </ul>
+        </nav>
       </Wrap>
     );
   }

--- a/client/src/pages/SearchPage/SearchPage.js
+++ b/client/src/pages/SearchPage/SearchPage.js
@@ -12,8 +12,58 @@ export default class SearchPage extends Component {
 
     this.state = {
       searchResult: {},
-      searchError: {}
+      searchError: {},
+      page: 1,
+      per_page: 10,
+      search: '',
     };
+  }
+
+  search() {
+    const endpoint = this.props.match.params.endpoint;
+    const { search, page, per_page } = this.state;
+    axios.get(`/api/${endpoint}?search=${search}&page=${page}&per_page=${per_page}`, { headers: { Authorization: 'Bearer ' + this.props.token }})
+    .then(res => {
+      console.log(res.data);
+      this.setState({ searchResult: res.data });
+    })
+    .catch(err => {
+      this.setState({ searchError: {
+        text: err.response.status + ' ' + err.response.statusText,
+        type: 'alert-danger'
+      }});
+    });
+  }
+
+  hasNextPage() {
+    let nextPage = this.state.page + 1;
+    const { searchResult } = this.state;
+    if (searchResult && searchResult._meta && searchResult._meta.total_pages) {
+      if (nextPage <= searchResult._meta.total_pages) {
+        return true;
+      }
+    }
+  }
+
+  hasLastPage() {
+    const lastPage = this.state.page - 1;
+    if (lastPage > 0) {
+      return true;
+    }
+  }
+
+  nextPage() {
+    const nextPage = this.state.page + 1;
+    if (this.hasNextPage()) {
+      this.setState({ page: nextPage}, this.search);
+    }
+  }
+
+  lastPage() {
+    const lastPage = this.state.page - 1;
+    if (this.hasLastPage()) {
+      this.setState({ page: lastPage }, this.search);
+    }
   }
 
   deleteItem(id, i) {
@@ -37,30 +87,13 @@ export default class SearchPage extends Component {
     this.setState(obj);
   }
 
-  defaultSearch() {
-    axios.get(`/api/${this.props.match.params.endpoint}`, {
-      headers: {
-        Authorization: 'Bearer ' + this.props.token
-      }
-    })
-      .then(res => {
-        this.setState({ searchResult: res.data, searchError: {} });
-      })
-      .catch(err => {
-        this.setState({ searchError: {
-          text: err.response.status + ' ' + err.response.statusText,
-          type: 'alert-danger'
-        }});
-      });
-  }
-
   componentDidMount() {
-    this.defaultSearch();
+    this.search();
   }
 
   componentWillReceiveProps(props) {
     if (props.match.params.endpoint !== this.props.match.params.endpoint) {
-      this.setState({ searchResult: {}, searchError: {}}, this.defaultSearch);
+      this.setState({ searchResult: {}, searchError: {}, search: ''}, this.search);
     }
   }
 
@@ -75,7 +108,9 @@ export default class SearchPage extends Component {
         <SearchBar
           title={endpoints[endpoint] ? endpoints[endpoint].title : ''}
           endpoint={endpoint}
-          set={this.set.bind(this)}
+          setValue={this.set.bind(this)}
+          search={this.state.search}
+          submitSearch={this.search.bind(this)}
           addBtn={true}
         />
         <br/>
@@ -93,6 +128,26 @@ export default class SearchPage extends Component {
             );
           }) : <p className="text-danger">None Found.</p>}
         </ul>
+        <br/>
+        <nav className="text-center row justify-content-center">
+          <ul className="pagination">
+            <li className="page-item">
+              <button className={`btn btn-${this.hasLastPage() ? 'info': 'primary'}`} disabled={!this.hasLastPage()} onClick={this.lastPage.bind(this)}>
+                <span aria-hidden="true">&laquo; </span>
+                <span className=""> Last</span>
+              </button>
+            </li>
+            <li className="page-item">
+              <button className="btn btn-info" disabled>{this.state.page}</button>
+            </li>
+            <li className="page-item">
+              <button className={`btn btn-${this.hasNextPage() ? 'info': 'primary'}`} disabled={!this.hasNextPage()} onClick={this.nextPage.bind(this)}>
+                <span>Next </span>
+                <span aria-hidden="true">&raquo;</span>
+              </button>
+            </li>
+          </ul>
+        </nav>
       </Dash>
     );
   }

--- a/client/src/pages/SearchPage/SearchPage.js
+++ b/client/src/pages/SearchPage/SearchPage.js
@@ -24,7 +24,6 @@ export default class SearchPage extends Component {
     const { search, page, per_page } = this.state;
     axios.get(`/api/${endpoint}?search=${search}&page=${page}&per_page=${per_page}`, { headers: { Authorization: 'Bearer ' + this.props.token }})
     .then(res => {
-      console.log(res.data);
       this.setState({ searchResult: res.data });
     })
     .catch(err => {


### PR DESCRIPTION
Close #97 
I chose to display 10 items per page. This can be changed in a search page. For example, in src/pages/SearchPage/SearchPage.js, if you change the per_page variable, you can adjust how many items are displayed per page.

constructor(props) {
  this.state = {
    per_page: 10
  }
}

**These pages should have pagination:**
/opportunities
/partners
/dashboard/:endpoint/search