### PR TITLE
bug fix: Select component defaults value to first item found in GET request

### DIFF
--- a/client/src/objects/Select/Select.js
+++ b/client/src/objects/Select/Select.js
@@ -19,7 +19,8 @@ export default class Select extends Component {
         this.setState({
           options: res.data.items.map(item => {
             return item[this.props.getOptions.property];
-          })
+          })}, () => {
+          this.props.setValue({ [this.props.name]: this.state.options[0] });
         });
       });
   }


### PR DESCRIPTION
I found this issue while reviewing. When I *don't* select a partner from <Select>, I get 400 partner_name must be defined error. This is because Select is not setting a default partner. I fixed this.