### PR TITLE
bug fix: removed name/partner_name check from api for PUT /api/opport…

### DIFF
--- a/volunteercore/api/volops/opportunities.py
+++ b/volunteercore/api/volops/opportunities.py
@@ -53,10 +53,6 @@ def get_opportunities_api():
 def update_opportunity_api(id):
     opportunity = Opportunity.query.get_or_404(id)
     data = request.get_json() or {}
-    if 'name' in data and Opportunity.query.filter_by(
-            name=data['name'], partner_id=Partner.query.filter_by(
-            name=data['partner_name']).first().id).first():
-        return bad_request('please use a different opportunity name')
     if 'partner_name' in data:
         data['partner_id'] = Partner.query.filter_by(
             name=data['partner_name']).first().id


### PR DESCRIPTION
Close #114 

Removed if statement in PUT /api/opportunities

@stevenabadie I tested this locally. This is how things should behave:

1. User edits fields on an opportunity and **does not modify the name field**.
2. User hits "submit"
3. User gets "Success!" message.

1. User tries to add a new opportunity
2. User NOT allowed to have same name as another opportunity with a given partner.
    * For example, opp A with VOA is called "code". opp B with VOA is NOT allowed to be called "code".

I don't use python much at all, but this appears to be working well.

