### PR TITLE
UI/UX: Separate Admin Dashboard from /opportunities and /partners CRUD.

### DIFF
--- a/client/src/components/App/App.js
+++ b/client/src/components/App/App.js
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
 import ROUTES from './routes.js';
-import './App.scss';
 import axios from 'axios';
+import Page404 from '../../pages/Page404/Page404';
+import './App.scss';
+
 
 class App extends Component {
   constructor(props) {
@@ -36,6 +38,12 @@ class App extends Component {
           {ROUTES.map((route) => {
             const C = route.component;
             route.component = (props) => {
+              if (route.admin) {
+                const { user } = this.state;
+                if (!user || !user.roles || user.roles.indexOf('Admin') === -1) {
+                  return <Page404 key={'r-' + route.path} {...this.state} {...props}/>;
+                }
+              }
               return <C set={this.set.bind(this)} {...this.state} {...props}/>
             };
             return (<Route exact {...route} key={'r-' + route.path}/>);

--- a/client/src/components/App/routes.js
+++ b/client/src/components/App/routes.js
@@ -8,11 +8,23 @@ module.exports = [{
   path: '/opportunities',
   component: require('../../pages/Opportunities/Opportunities').default
 }, {
-  path: '/opportunities/:id',
-  component: require('../../pages/Opportunity/Opportunity.js').default
+  path: '/opportunities/view/:id',
+  component: require('../../pages/Opportunities/ViewOpportunity/ViewOpportunity').default
+}, {
+  path: '/opportunities/post',
+  component: require('../../pages/Opportunities/PostOpportunity/PostOpportunity').default
+}, {
+  path: '/opportunities/edit/:id',
+  component: require('../../pages/Opportunities/PutOpportunity/PutOpportunity').default
 }, {
   path: '/partners',
   component: require('../../pages/Partners/Partners.js').default
+}, {
+  path: '/partners/post',
+  component: require('../../pages/Partners/PostPartner/PostPartner.js').default
+}, {
+  path: '/partners/edit/:id',
+  component: require('../../pages/Partners/PutPartner/PutPartner').default
 }, {
   path: '/help',
   component: require('../../pages/Help/Help.js').default

--- a/client/src/components/App/routes.js
+++ b/client/src/components/App/routes.js
@@ -18,16 +18,20 @@ module.exports = [{
   component: require('../../pages/Help/Help.js').default
 }, {
   path: '/dashboard/:endpoint/search',
-  component: require('../../pages/SearchPage/SearchPage.js').default
+  component: require('../../pages/SearchPage/SearchPage.js').default,
+  admin: true
 }, {
   path: '/dashboard/:endpoint/add',
-  component: require('../../pages/PostPage/PostPage.js').default
+  component: require('../../pages/PostPage/PostPage.js').default,
+  admin: true
 }, {
   path: '/dashboard/:endpoint/edit/:id',
-  component: require('../../pages/PutPage/PutPage.js').default
+  component: require('../../pages/PutPage/PutPage.js').default,
+  admin: true
 }, {
   path: '/dashboard/:endpoint/view/:id',
-  component: require('../../pages/ViewPage/ViewPage.js').default
+  component: require('../../pages/ViewPage/ViewPage.js').default,
+  admin: true
 }, {
   component: require('../../pages/Page404/Page404.js').default
 }];

--- a/client/src/components/OppThumb/OppThumb.js
+++ b/client/src/components/OppThumb/OppThumb.js
@@ -35,8 +35,8 @@ export default class OpportunityThumb extends Component {
           })}
         </div>
         <div className="btn-group">
-          <Link className="btn btn-info btn-sm" to={`/partners/view/${id}`}>View</Link>
-          <Link className="btn btn-warning btn-sm" to={`/partners/edit/${id}`}>Edit</Link>
+          <Link className="btn btn-info btn-sm" to={`/opportunities/view/${id}`}>View</Link>
+          <Link className="btn btn-warning btn-sm" to={`/opportunities/edit/${id}`}>Edit</Link>
           <button className="btn btn-danger btn-sm" onClick={this.props.deleteOne.bind(this)}>Delete</button>
         </div>
       </div>

--- a/client/src/components/OppThumb/OppThumb.js
+++ b/client/src/components/OppThumb/OppThumb.js
@@ -17,9 +17,10 @@ export default class OpportunityThumb extends Component {
 
   render () {
     const tags = this.flattenTags(this.props.tags);
+    const { id } = this.props;
     return (
       <div className='opp-thumb'>
-        <Link to={`/opportunities/${this.props.id}`}>
+        <Link to={`/opportunities/view/${this.props.id}`}>
           <h4><u>{this.props.name}</u> - {this.props.partner_name}</h4>
         </Link>
         <p>{this.props.location_street} {this.props.location_city}, {this.props.location_state}, {this.props.location_zip}</p>
@@ -32,6 +33,11 @@ export default class OpportunityThumb extends Component {
           {tags.map(tag => {
             return <span className='badge badge-pill badge-primary'>{ tag }</span>
           })}
+        </div>
+        <div className="btn-group">
+          <Link className="btn btn-info btn-sm" to={`/partners/view/${id}`}>View</Link>
+          <Link className="btn btn-warning btn-sm" to={`/partners/edit/${id}`}>Edit</Link>
+          <button className="btn btn-danger btn-sm" onClick={this.props.deleteOne.bind(this)}>Delete</button>
         </div>
       </div>
     );

--- a/client/src/components/Pagination/Pagination.js
+++ b/client/src/components/Pagination/Pagination.js
@@ -1,0 +1,58 @@
+import React, { Component } from 'react';
+
+export default class Pagination extends Component {
+  hasNextPage() {
+    let nextPage = this.props.page + 1;
+    const { searchResult } = this.props;
+    if (searchResult && searchResult._meta && searchResult._meta.total_pages) {
+      if (nextPage <= searchResult._meta.total_pages) {
+        return true;
+      }
+    }
+  }
+
+  hasLastPage() {
+    const lastPage = this.props.page - 1;
+    if (lastPage > 0) {
+      return true;
+    }
+  }
+
+  nextPage() {
+    const nextPage = this.props.page + 1;
+    if (this.hasNextPage()) {
+      this.props.setValue({ page: nextPage}, this.props.search.bind(this));
+    }
+  }
+
+  lastPage() {
+    const lastPage = this.props.page - 1;
+    if (this.hasLastPage()) {
+      this.props.setValue({ page: lastPage }, this.props.search.bind(this));
+    }
+  }
+
+  render () {
+    return (
+      <nav className="text-center row justify-content-center">
+        <ul className="pagination">
+          <li className="page-item">
+            <button className={`btn btn-${this.hasLastPage() ? 'info': 'primary'}`} disabled={!this.hasLastPage()} onClick={this.lastPage.bind(this)}>
+              <span aria-hidden="true">&laquo; </span>
+              <span className=""> Last</span>
+            </button>
+          </li>
+          <li className="page-item">
+            <button className="btn btn-info" disabled>{this.props.page}</button>
+          </li>
+          <li className="page-item">
+            <button className={`btn btn-${this.hasNextPage() ? 'info': 'primary'}`} disabled={!this.hasNextPage()} onClick={this.nextPage.bind(this)}>
+              <span>Next </span>
+              <span aria-hidden="true">&raquo;</span>
+            </button>
+          </li>
+        </ul>
+      </nav>
+    );
+  }
+}

--- a/client/src/components/PartnerThumb/PartnerThumb.js
+++ b/client/src/components/PartnerThumb/PartnerThumb.js
@@ -1,18 +1,18 @@
 import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
 import './PartnerThumb.scss';
 
-export default class OpportunityThumb extends Component {
+export default class PartnerThumb extends Component {
   render () {
+    const { id } = this.props;
     return (
       <div className='opp-thumb'>
-        <h4><u>{this.props.name}</u> - {this.props.partner_name}</h4>
-        <p>{this.props.location_street} {this.props.location_city}, {this.props.location_state}, {this.props.location_zip}</p>
-        <p>{this.props.shift_hours} Hour - {this.props.frequency} - {this.props.commitment_length} - {this.props.commitment_length}</p>
-        <div>
-          <span className='badge badge-pill badge-primary'> Children </span>
-          <span className='badge badge-pill badge-primary'> Art </span>
-          <span className='badge badge-pill badge-primary'> Teaching </span>
-          <span className='badge badge-pill badge-primary'> Cooking </span>       
+        <h4>{this.props.name} - {this.props.opportunity_count}</h4>
+        <div className="btn-group">
+          {/*<Link className="btn btn-info btn-sm" to={`/partners/view/${id}`}>View</Link>
+          */}
+          <Link className="btn btn-warning btn-sm" to={`/partners/edit/${id}`}>Edit</Link>
+          <button className="btn btn-danger btn-sm" onClick={this.props.deleteOne.bind(this)}>Delete</button>
         </div>
       </div>
     );

--- a/client/src/components/PutForm/PutForm.js
+++ b/client/src/components/PutForm/PutForm.js
@@ -1,0 +1,109 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import Wrap from '../../components/Wrap/Wrap.js';
+import Form from '../../objects/Form/Form.js';
+import Alert from '../../components/Alert/Alert.js';
+import axios from 'axios';
+import endpoints from '../../utils/endpoints.js';
+import parse from '../../utils/parseFields.js';
+
+export default class PostPage extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      data: endpoints.fieldsToState(this.props.endpoint),
+      response: {}
+    };
+  }
+
+  submitForm(e) {
+    e.preventDefault();
+    let { data } = this.state;
+    const endpoint = this.props.endpoint;
+    data = parse.parseData(data, this.props.endpoint);
+
+    axios.put(`/api/${endpoint}/${data.id}`, data, {
+      headers: {
+        Authorization: 'Bearer ' + this.props.token
+      }
+    }).then(() => {
+        this.setState({
+          response: {
+            type: 'alert-success',
+            text: 'Success!'
+          }
+        })
+      })
+      .catch(err => {
+        this.setState({
+          response: {
+            type: 'alert-danger',
+            text: err.response.data.message ? 
+              'Error: ' + err.response.data.message : err.message
+          }
+        })
+      });
+  }
+
+  setValue(obj) {
+    let data = this.state.data;
+    let key = Object.keys(obj)[0];
+    data[key] = obj[key];
+    this.setState({ data });
+  }
+
+  componentDidMount() {
+    this._isMounted = true;
+    axios.get(`/api/${this.props.endpoint}/${this.props.match.params.id}`, {
+      headers: {
+        Authorization: 'Bearer ' + this.props.token
+      }})
+      .then(res => {
+        this.setState({ data: parse.formatData(res.data, this.props.endpoint) });
+      })
+      .catch(err => {
+        this.setState({ response: err });
+      })
+  }
+
+  render () {
+    const endpoint = this.props.endpoint;
+    return (
+      <Wrap {...this.props}>
+        <h3>Edit {endpoint}</h3>
+        <nav aria-label="breadcrumb">
+          <ol className="breadcrumb">
+            <li className="breadcrumb-item">
+              <Link 
+                className="text-info"
+                to={`/${endpoint}`}>
+                Search {endpoint}
+              </Link>
+            </li>
+            <li className="breadcrumb-item">
+              Edit {endpoint}
+            </li>
+          </ol>
+        </nav>
+        <div className="card border-warning">
+          <div className="card-header bg-warning border-warning text-light">
+            Thanks for using Volunteer Core!
+          </div>
+          <div className="card-body">
+            <Form
+              submitForm={this.submitForm.bind(this)}
+              data={this.state.data}
+              fields={endpoints[endpoint].fields}
+              setValue={this.setValue.bind(this)}
+              submitBtnClass='btn-warning'
+              token={this.props.token}
+            />
+            <br/>
+            <Alert type={this.state.response.type} text={this.state.response.text}/>
+          </div>
+        </div>
+      </Wrap>
+    );
+  }
+}

--- a/client/src/components/SearchBar/SearchBar.js
+++ b/client/src/components/SearchBar/SearchBar.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
-import axios from 'axios';
 import './SearchBar.scss';
 
 export default class SearchBar extends Component {
@@ -25,7 +24,11 @@ export default class SearchBar extends Component {
               <Link className="btn btn-info add-btn" to={`/dashboard/${this.props.endpoint}/add`}>
                 Add {this.props.endpoint}
               </Link>
-            ): ''}
+            ): this.props.postUrl ? (
+              <Link className="btn btn-info add-btn" to={this.props.postUrl}>
+                Add {this.props.endpoint}
+              </Link>
+            ) : ''}
           </div>
         </div>
       </form>

--- a/client/src/pages/Opportunities/Opportunities.js
+++ b/client/src/pages/Opportunities/Opportunities.js
@@ -3,6 +3,7 @@ import Wrap from '../../components/Wrap/Wrap.js';
 import Thumb from '../../components/OppThumb/OppThumb.js';
 import SearchBar from '../../components/SearchBar/SearchBar.js';
 import Alert from '../../components/Alert/Alert.js';
+import Pagination from '../../components/Pagination/Pagination';
 import './Opportunity.scss';
 import axios from 'axios';
 
@@ -33,39 +34,8 @@ export default class Opportunties extends Component {
     });
   }
 
-  hasNextPage() {
-    let nextPage = this.state.page + 1;
-    const { searchResult } = this.state;
-    if (searchResult && searchResult._meta && searchResult._meta.total_pages) {
-      if (nextPage <= searchResult._meta.total_pages) {
-        return true;
-      }
-    }
-  }
-
-  hasLastPage() {
-    const lastPage = this.state.page - 1;
-    if (lastPage > 0) {
-      return true;
-    }
-  }
-
-  nextPage() {
-    const nextPage = this.state.page + 1;
-    if (this.hasNextPage()) {
-      this.setState({ page: nextPage}, this.search);
-    }
-  }
-
-  lastPage() {
-    const lastPage = this.state.page - 1;
-    if (this.hasLastPage()) {
-      this.setState({ page: lastPage }, this.search);
-    }
-  }
-
-  set(obj) {
-    this.setState(obj);
+  setValue(obj, cb) {
+    this.setState(obj, cb);
   }
 
   componentDidMount() {
@@ -80,7 +50,7 @@ export default class Opportunties extends Component {
         <h2>Search Opportunities</h2>
         <SearchBar
           endpoint='opportunities'
-          setValue={this.set.bind(this)}
+          setValue={this.setValue.bind(this)}
           search={this.state.search}
           submitSearch={this.search.bind(this)}
         />
@@ -89,25 +59,11 @@ export default class Opportunties extends Component {
         {items && items.length > 0 ? items.map((val) => {
           return <Thumb {...val}/>;
         }): <p className="text-danger">No Opportunities found.</p>}
-        <nav className="text-center row justify-content-center">
-          <ul className="pagination">
-            <li className="page-item">
-              <button className={`btn btn-${this.hasLastPage() ? 'info': 'primary'}`} disabled={!this.hasLastPage()} onClick={this.lastPage.bind(this)}>
-                <span aria-hidden="true">&laquo; </span>
-                <span className=""> Last</span>
-              </button>
-            </li>
-            <li className="page-item">
-              <button className="btn btn-info" disabled>{this.state.page}</button>
-            </li>
-            <li className="page-item">
-              <button className={`btn btn-${this.hasNextPage() ? 'info': 'primary'}`} disabled={!this.hasNextPage()} onClick={this.nextPage.bind(this)}>
-                <span>Next </span>
-                <span aria-hidden="true">&raquo;</span>
-              </button>
-            </li>
-          </ul>
-        </nav>
+        <Pagination
+          {...this.state}
+          setValue={this.setValue.bind(this)}
+          search={this.search.bind(this)}
+        />
       </Wrap>
     );
   }

--- a/client/src/pages/Opportunities/Opportunities.js
+++ b/client/src/pages/Opportunities/Opportunities.js
@@ -53,6 +53,7 @@ export default class Opportunties extends Component {
           setValue={this.setValue.bind(this)}
           search={this.state.search}
           submitSearch={this.search.bind(this)}
+          postUrl="/opportunities/post"
         />
         <Alert {...this.state.searchError}/>
         <br/><br/>

--- a/client/src/pages/Opportunities/Opportunities.js
+++ b/client/src/pages/Opportunities/Opportunities.js
@@ -38,6 +38,20 @@ export default class Opportunties extends Component {
     this.setState(obj, cb);
   }
 
+  deleteOne(index) {
+    const token = this.props.token;
+    let searchResult = this.state.searchResult;
+    let id = searchResult.items[index].id;
+    axios.delete(`/api/opportunities/${id}`, { headers: { Authorization: `Bearer ${token}`}})
+      .then(res => {
+        searchResult.items.splice(index, 1);
+        this.setState({ searchResult });
+      })
+      .catch(err => {
+        alert('Delete Failed. Please try again.');
+      });
+  }
+
   componentDidMount() {
     this.search();
   }
@@ -57,8 +71,13 @@ export default class Opportunties extends Component {
         />
         <Alert {...this.state.searchError}/>
         <br/><br/>
-        {items && items.length > 0 ? items.map((val) => {
-          return <Thumb {...val}/>;
+        {items && items.length > 0 ? items.map((val, i) => {
+          return (
+            <Thumb
+              {...val}
+              deleteOne={() => { this.deleteOne(i) }}
+            />
+          );
         }): <p className="text-danger">No Opportunities found.</p>}
         <Pagination
           {...this.state}

--- a/client/src/pages/Opportunities/PostOpportunity/PostOpportunity.js
+++ b/client/src/pages/Opportunities/PostOpportunity/PostOpportunity.js
@@ -1,0 +1,97 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import Wrap from '../../../components/Wrap/Wrap';
+import Form from '../../../objects/Form/Form.js';
+import Alert from '../../..//components/Alert/Alert.js';
+import axios from 'axios';
+import parse from '../../../utils/parseFields';
+
+import endpoints from '../../../utils/endpoints.js';
+
+export default class PostOpportunity extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      data: {},
+      response: {}
+    };
+  }
+
+  removeDashes(str) {
+    let copy = str;
+    return copy.replace(/-/gi, '');
+  }
+
+  submitForm(e) {
+    e.preventDefault();
+    let { data } = this.state;
+
+    data = parse.parseData(data, 'opportunities');
+
+    axios.post('/api/opportunities', data, {
+      headers: {
+        Authorization: 'Bearer ' + this.props.token
+      }
+    })
+      .then(res => {
+        this.setState({ response: {
+          type: 'alert-success',
+          text: 'Success!'
+        }});
+      })
+      .catch(err => {
+        this.setState({ response: {
+          type: 'alert-danger',
+          text: err.response.data.message ?
+            'Error: ' + err.response.data.message : err.message
+        }});
+      });
+  }
+
+  setValue(obj) {
+    let data = this.state.data;
+    let key = Object.keys(obj)[0];
+    data[key] = obj[key];
+    this.setState({ data });
+  }
+
+  render () {
+    return (
+      <Wrap  {...this.props}>
+        <h3>Add Opportunities</h3>
+        <nav aria-label="breadcrumb">
+          <ol className="breadcrumb">
+            <li className="breadcrumb-item">
+              <Link
+                className="text-info"
+                to={'/opportunities'}>
+                Search Opportunities
+              </Link>
+            </li>
+            <li className="breadcrumb-item">
+              Add Opportunities
+            </li>
+          </ol>
+        </nav>
+        <div className="card border-info">
+          <div className="card-header bg-info border-info text-light">
+            Thanks for using Volunteer Core!
+          </div>
+          <div className="card-body">
+            <Form
+              submitForm={this.submitForm.bind(this)}
+              data={this.state.data}
+              fields={endpoints.opportunities.fields}
+              setValue={this.setValue.bind(this)}
+              submitBtnClass='btn-info'
+              token={this.props.token}
+            />
+            <br/>
+            <Alert type={this.state.response.type} text={this.state.response.text}/>
+          </div>
+        </div>
+      </Wrap>
+    );
+  }
+}

--- a/client/src/pages/Opportunities/PutOpportunity/PutOpportunity.js
+++ b/client/src/pages/Opportunities/PutOpportunity/PutOpportunity.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+import PutForm from '../../../components/PutForm/PutForm';
+
+export default class PutOpportunity extends Component {
+  render () {
+    return (
+      <PutForm
+        {...this.props}
+        endpoint='opportunities'
+      >
+      </PutForm>
+    );
+  }
+}

--- a/client/src/pages/Opportunities/ViewOpportunity/ViewOpportunity.js
+++ b/client/src/pages/Opportunities/ViewOpportunity/ViewOpportunity.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import Wrap from '../../../components/Wrap/Wrap.js';
+import { Link } from 'react-router-dom';
+import axios from 'axios';
+
+export default class ViewOpportunity extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      opportunity: {}
+    }
+  }
+
+  componentDidMount() {
+    axios.get('/api/opportunities/' + this.props.match.params.id)
+      .then(res => {
+        this.setState({ opportunity: res.data });
+      })
+      .catch(err => {
+        alert(err);
+      });
+  }
+
+  render () {
+    const opp = this.state.opportunity;
+    return (
+      <Wrap {...this.props}>
+        <h1>{opp.partner_name || 'Loading...'}</h1>
+        <nav aria-label="breadcrumb">
+          <ol className="breadcrumb">
+            <li className="breadcrumb-item"><Link to="/opportunities" className="text-info">Opportunities</Link></li>
+            <li className="breadcrumb-item">{opp.partner_name || 'Loading...'}</li>
+          </ol>
+        </nav>
+        <div className="card">
+          <div className="card-header">
+            Volunteer for {opp.partner_name || 'Loading...'}
+          </div>
+          <div className="card-body">
+            <h3><u>{opp.name}</u> - {opp.partner_name}</h3>
+            {opp ? Object.keys(opp).map(key => {
+              if (!opp[key]) return '';
+              switch(key) {
+                case 'id': return '';
+                case 'partner_string': return '';
+              }
+              return <p><b>{key}:</b> {opp[key]}</p>;
+            }): ''}
+          </div>
+        </div>
+      </Wrap>
+    );
+  }
+}

--- a/client/src/pages/Partners/PostPartner/PostPartner.js
+++ b/client/src/pages/Partners/PostPartner/PostPartner.js
@@ -1,0 +1,97 @@
+import React, { Component } from 'react';
+import { Link } from 'react-router-dom';
+import Wrap from '../../../components/Wrap/Wrap';
+import Form from '../../../objects/Form/Form.js';
+import Alert from '../../..//components/Alert/Alert.js';
+import axios from 'axios';
+import parse from '../../../utils/parseFields';
+
+import endpoints from '../../../utils/endpoints.js';
+
+export default class PostOpportunity extends Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      data: {},
+      response: {}
+    };
+  }
+
+  removeDashes(str) {
+    let copy = str;
+    return copy.replace(/-/gi, '');
+  }
+
+  submitForm(e) {
+    e.preventDefault();
+    let { data } = this.state;
+
+    data = parse.parseData(data, 'partners');
+
+    axios.post('/api/partners', data, {
+      headers: {
+        Authorization: 'Bearer ' + this.props.token
+      }
+    })
+      .then(res => {
+        this.setState({ response: {
+          type: 'alert-success',
+          text: 'Success!'
+        }});
+      })
+      .catch(err => {
+        this.setState({ response: {
+          type: 'alert-danger',
+          text: err.response.data.message ?
+            'Error: ' + err.response.data.message : err.message
+        }});
+      });
+  }
+
+  setValue(obj) {
+    let data = this.state.data;
+    let key = Object.keys(obj)[0];
+    data[key] = obj[key];
+    this.setState({ data });
+  }
+
+  render () {
+    return (
+      <Wrap  {...this.props}>
+        <h3>Add Partners</h3>
+        <nav aria-label="breadcrumb">
+          <ol className="breadcrumb">
+            <li className="breadcrumb-item">
+              <Link
+                className="text-info"
+                to={'/partners'}>
+                Search Partners
+              </Link>
+            </li>
+            <li className="breadcrumb-item">
+              Add Partners
+            </li>
+          </ol>
+        </nav>
+        <div className="card border-info">
+          <div className="card-header bg-info border-info text-light">
+            Thanks for using Volunteer Core!
+          </div>
+          <div className="card-body">
+            <Form
+              submitForm={this.submitForm.bind(this)}
+              data={this.state.data}
+              fields={endpoints.partners.fields}
+              setValue={this.setValue.bind(this)}
+              submitBtnClass='btn-info'
+              token={this.props.token}
+            />
+            <br/>
+            <Alert type={this.state.response.type} text={this.state.response.text}/>
+          </div>
+        </div>
+      </Wrap>
+    );
+  }
+}

--- a/client/src/pages/Partners/PutPartner/PutPartner.js
+++ b/client/src/pages/Partners/PutPartner/PutPartner.js
@@ -1,0 +1,14 @@
+import React, { Component } from 'react';
+import PutForm from '../../../components/PutForm/PutForm';
+
+export default class PutOpportunity extends Component {
+  render () {
+    return (
+      <PutForm
+        {...this.props}
+        endpoint='partners'
+      >
+      </PutForm>
+    );
+  }
+}

--- a/client/src/pages/ViewOpportunity/Opportunity.js
+++ b/client/src/pages/ViewOpportunity/Opportunity.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import Wrap from '../../components/Wrap/Wrap.js';
+import Wrap from '../../../components/Wrap/Wrap.js';
 import { Link } from 'react-router-dom';
 import axios from 'axios';
 


### PR DESCRIPTION
Close #113 

This PR makes /opportunities and /partners CRUD _functional_ outside of the dashboard. There were a lot of changes, but this is the gist of it:

1. I can CRUD opportunities and partners on the /opportunities and /partners pages
2. Non-Admin users get a 404 not found when they hit the /dashboard pages
3. Other code organization

Some UI is still ugly, so we can make an issue for that. This pr's purpose is just to get the functional, working pages out there.
 