### PR TITLE
bug fix: UI/UX: On Firefox, double scroll bars in dashboard.

### DIFF
--- a/client/src/components/Dashboard/Dashboard.scss
+++ b/client/src/components/Dashboard/Dashboard.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   @media screen and (min-width: $xs) {
-    height: 100vh;
+    height: 100%;
   }
 }
 
@@ -12,7 +12,6 @@
   display: flex;
   flex-direction: column;
   @media screen and (min-width: $xs) {
-    height: 100%;
     flex-direction: row;
   }
 }


### PR DESCRIPTION
Close #118 

My original thoughts were to make the sidebar fixed, but considering that no form requires you to scroll (if you're on most any desktop.) I figured I'd just remove the secondary scrolling for now.