### PR TITLE
UX: Made DashListItem mobile responsive

### DIFF
--- a/client/src/components/DashListItem/DashListItem.js
+++ b/client/src/components/DashListItem/DashListItem.js
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
+import './DashListItem.scss';
 
 export default class DashListItem extends Component {
   render () {
     return (
-      <li className="list-group-item d-flex justify-content-between align-items-center">
+      <li className="dash-list-item list-group-item d-flex">
         {this.props.text}
-        <div>
+        <div className="dash-list-item-btns">
           <Link className="btn btn-info btn-sm" to={`/dashboard/${this.props.endpoint}/view/${this.props.id}`}>View</Link>
           <Link 
             className="btn btn-warning btn-sm" 

--- a/client/src/components/DashListItem/DashListItem.scss
+++ b/client/src/components/DashListItem/DashListItem.scss
@@ -1,0 +1,10 @@
+@import '../../utils/variables';
+
+.dash-list-item {
+  flex-direction: column;
+  align-items: center;
+  @media screen and (min-width: $xs) {
+    flex-direction: row;
+    justify-content: space-between;
+  }
+}

--- a/client/src/components/Dashboard/Dashboard.scss
+++ b/client/src/components/Dashboard/Dashboard.scss
@@ -4,7 +4,7 @@
   display: flex;
   flex-direction: column;
   @media screen and (min-width: $xs) {
-    height: 100vh;
+    height: 100%;
   }
 }
 
@@ -12,7 +12,6 @@
   display: flex;
   flex-direction: column;
   @media screen and (min-width: $xs) {
-    height: 100%;
     flex-direction: row;
   }
 }


### PR DESCRIPTION
Close #75 

the DashListItem component is mobile responsive now.  This is the component in the /dashboard routes that displays a name/organization then a "view", "edit", and "delete" button.

These buttons are now on a separate row from the name/organization text on mobile.