### PR TITLE
Fix opportunity tags import and make opportunity search only search tags

### DIFF
--- a/volunteercore/api/volops/import_data.py
+++ b/volunteercore/api/volops/import_data.py
@@ -139,6 +139,7 @@ def import_opportunity_tags():
                 opportunity.tags.append(Tag.query.filter_by(
                     tag_category_id=tag_category_id,
                     name=row['tag']).first())
+                opportunity.update_tag_strings()
                 db.session.add(opportunity)
                 db.session.commit()
                 index_one_record(opportunity)
@@ -146,3 +147,14 @@ def import_opportunity_tags():
         open_csv.close()
         os.remove(os.path.join(Config.UPLOAD_FOLDER, import_filename))
         return str(items_imported) + ' opportunity tags imported'
+
+
+@bp.route('/api/import/set_tags_string', methods=['POST'])
+@login_required
+@requires_roles('Admin')
+def set_tags_string():
+    for opportunity in Opportunity.query.all():
+        opportunity.update_tag_strings()
+        db.session.add(opportunity)
+        db.session.commit()
+    return 'opportunity tags strings set', 201

--- a/volunteercore/volops/models.py
+++ b/volunteercore/volops/models.py
@@ -37,8 +37,7 @@ class Partner(PagininatedAPIMixin, db.Model):
 
 class Opportunity(PagininatedAPIMixin, db.Model):
     __tablename__ = 'opportunity'
-    __searchable__ = ['name', 'location_city', 'location_zip',
-                      'tags_string', 'partner_string']
+    __searchable__ = ['tags_string']
 
     id = db.Column(db.Integer(), primary_key=True, index=True)
     active = db.Column(db.Boolean())


### PR DESCRIPTION
This fix is to address part of #155. This fixes the /api/import/opportunity_tags endpoint to correctly set the opportunity.tags_string field. To continue testing, this also makes opportunity search only search the tags_string field. This also adds an endpoint to generate tags_string field to fix existing imports.

To test this with an existing database that has imported data first hit the /api/import/set_tags_string endpoint to correctly set the opportunity tags_string field. You can do this with httpie with your corrected user:password and the location where you want to store the session:

```
http -a admin:password POST http://127.0.0.1:5000/api/auth/login --session=/tmp/session.json
http POST http://127.0.0.1:5000/api/import/set_tags_string --session=/tmp/session.json
```
Then you should delete everything in the /whoosh/ directory and run flask `whoosh-index-all` to re-index the data. Now searching tags show work better.

This should get testing moving again but I would like to leave #155 open to replace Whoosh with a better search query to allow weighting opportunity search across multiple fields.